### PR TITLE
[BUILD] restrict flake8 version and change the test environment 

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ test_deps = [
     'pytest>=4',
     'pytest-cov>=2.6.0',
     'pytest-flake8',
+    'flake8<5.0.0'
 ]
 
 setup(


### PR DESCRIPTION
Thanks for sending a pull request! 
Please make sure you click the link above to view the [contribution guidelines](https://github.com/bigdata-ustc/EduData/blob/master/CONTRIBUTE.md), 
then fill out the blanks below.

## Description ##
(Brief description on what this PR is about)

### What does this implement/fix? Explain your changes.
1. restrict the flake8 version under 5.0.0
2. remove py3.6 from test env and add 3.10

#### Pull request type
- [ ] [DATASET] Add a new dataset
- [] [BUGFIX] Bugfix
- [ ] [FEATURE] New feature (non-breaking change which adds functionality)
- [ ] [BREAKING] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] [STYLE] Code style update (formatting, renaming)
- [ ] [REFACTOR] Refactoring (no functional changes, no api changes)
- [x] [BUILD] Build related changes
- [ ] [DOC] Documentation content changes
- [ ] [OTHER] Other (please describe): 


#### Changes
1. restrict the flake8 version under 5.0.0
2. remove py3.6 from test env and add 3.10

### Does this close any currently open issues?
N/A

### Any relevant logs, error output, etc?
N/A

## Checklist ##
Before you submit a pull request, please make sure you have to following:

### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [FEATURE], [BREAKING], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage and al tests passing
- [x] Code is well-documented (extended the README / documentation, if necessary)
- [x] If this PR is your first one, add your name and github account to [AUTHORS.md](https://github.com/bigdata-ustc/EduData/blob/master/AUTHORS.md)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
